### PR TITLE
[BotFramework-Connector] Fix webpack breaking issue with polyfill

### DIFF
--- a/libraries/botframework-connector/src/index.ts
+++ b/libraries/botframework-connector/src/index.ts
@@ -1,4 +1,4 @@
-(new Function('require', 'const env = (global || window); if (!env.hasOwnProperty("FormData")) { env.FormData = require("form-data"); }; if (!env.hasOwnProperty("fetch")) { env.fetch = require("node-fetch"); }'))(require);
+(new Function('require', 'if (!this.hasOwnProperty("FormData")) { this.FormData = require("form-data"); }; if (!this.hasOwnProperty("fetch")) { this.fetch = require("node-fetch"); }'))(require);
 
 import { TokenResponse } from './connectorApi/models/mappers';
 


### PR DESCRIPTION
## Description
After removing the ```request``` dependency from the botframework-connector library the bundling of the app using WebPack would throw a missing dependencies error and fail (see issue 818).

![image](https://user-images.githubusercontent.com/20074735/56676450-b044c280-6694-11e9-9d98-eece3b484bf5.png)


## Specific Changes
We removed the conditional imports in botframework-connector and replaced a variable (```env```) that was being initialized to ```global``` or ```window``` depending on the bot running locally or on a browser, and directly replaced its instances by a call to ```this``` which holds that value. This is because the function, being called through its constructor, will execute in the **global** scope ([https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function))

**Code before this modification was:**
``` javascript
(new Function('require', 'const env = (global || window); if (!env.hasOwnProperty("FormData")) { env.FormData = require("form-data"); }; if (!env.hasOwnProperty("fetch")) { env.fetch = require("node-fetch"); }'))(require);
```

**Was changed to:**
``` javascript
(new Function('require', 'if (!this.hasOwnProperty("FormData")) { this.FormData = require("form-data"); }; if (!this.hasOwnProperty("fetch")) { this.fetch = require("node-fetch"); }'))(require);
```

[Line changed](https://github.com/southworkscom/botbuilder-js/blob/2af5a82753b67c0f624c4c4a76025924da24ceef/libraries/botframework-connector/src/index.ts#L1)

## Testing
We ran the unit tests after this change and they all passed successfully
![image](https://user-images.githubusercontent.com/20074735/56686925-7d59f900-66ab-11e9-8ea7-c496666f05da.png)




