### PR TITLE
[BotBuilder-AI] Remove 'html-entities' from QnA Maker class

### DIFF
--- a/libraries/botbuilder-ai/package.json
+++ b/libraries/botbuilder-ai/package.json
@@ -21,12 +21,10 @@
   "typings": "./lib/index.d.ts",
   "dependencies": {
     "@microsoft/recognizers-text-date-time": "1.1.2",
-    "@types/html-entities": "^1.2.16",
     "@types/node": "^10.12.18",
     "@types/request-promise-native": "^1.0.10",
     "@azure/cognitiveservices-luis-runtime": "2.0.0",
     "botbuilder-core": "~4.1.6",
-    "html-entities": "^1.2.1",
     "moment": "^2.20.1",
     "@azure/ms-rest-js": "~1.8.2",
     "request": "^2.87.0",

--- a/libraries/botbuilder-ai/src/qnaMaker.ts
+++ b/libraries/botbuilder-ai/src/qnaMaker.ts
@@ -6,7 +6,6 @@
  * Licensed under the MIT License.
  */
 import { Activity, TurnContext, BotTelemetryClient, NullTelemetryClient } from 'botbuilder-core';
-import * as entities from 'html-entities';
 import * as os from 'os';
 const pjson: any = require('../package.json');
 import * as request from 'request-promise-native';
@@ -16,11 +15,6 @@ import { QnATelemetryConstants } from './qnaTelemetryConstants';
 const QNAMAKER_TRACE_TYPE = 'https://www.qnamaker.ai/schemas/trace';
 const QNAMAKER_TRACE_NAME = 'QnAMaker';
 const QNAMAKER_TRACE_LABEL = 'QnAMaker Trace';
-
-/**
- * @private
- */
-const htmlentities: entities.AllHtmlEntities = new entities.AllHtmlEntities();
 
 /**
  * An individual answer returned by a call to the QnA Maker Service.
@@ -579,7 +573,6 @@ export class QnAMaker implements QnAMakerTelemetryClient {
     private formatQnaResult(qnaResult: any): QnAMakerResult[] {
         return qnaResult.answers.map((ans: any) => {
             ans.score = ans.score / 100;
-            ans.answer = htmlentities.decode(ans.answer);
 
             if (ans.qnaId) {
                 ans.id = ans.qnaId;


### PR DESCRIPTION
## Description
- Remove `html-entities` library and its decoding from the answer formatting.

## Specific Changes
At this moment when the QnA Maker class in BotBuilder AI receives an answer that contains enconded HTML entities, said entities are [decoded before returning the answer](https://github.com/Microsoft/botbuilder-js/blob/master/libraries/botbuilder-ai/src/qnaMaker.ts#L582).

Remove this behaviour from the QnA Maker answer formatting, as this responsibility should be delegated to the user consuming the answer.

## Testing
We did a couple of tests using both the NodeJS and .NET version of the class.
A knowledge base was created with a single answer containing several encoded HTML entities.

![image](https://user-images.githubusercontent.com/39467613/56962671-845e8c80-6b2d-11e9-9668-96d413a1b15d.png)

We tested the answer from the knowledge base by adding it to a `console.log()` and the `sendActivity()` using the [Echo Browser](https://github.com/Microsoft/BotBuilder-Samples/tree/master/samples/javascript_es6/01.a.browser-echo) bot sample.

![image](https://user-images.githubusercontent.com/39467613/56962541-3b0e3d00-6b2d-11e9-9fcd-8e87e25998d6.png)
As seen in the image above, the answer returned by the QnA Maker class does not match the answer stored in the knowledge base.

We also compared the behaviour of the JavaScript class against the .NET class replicating the same test.
![image](https://user-images.githubusercontent.com/39467613/56967567-d6a4ab00-6b37-11e9-9a52-4d0c2d26d049.png)

This test confirms that the behaviour of the QnA Maker class in .NET does not decode the HTML entities before returning the answer.