### PR TITLE
Update ms-rest-js to @azure/ms-rest-js

### DIFF
--- a/libraries/botbuilder-ai/package-lock.json
+++ b/libraries/botbuilder-ai/package-lock.json
@@ -5,9 +5,9 @@
 	"requires": true,
 	"dependencies": {
 		"@azure/ms-rest-js": {
-			"version": "1.8.2",
-			"resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-1.8.2.tgz",
-			"integrity": "sha512-xpXLTUztG/oYcyieN0GiS9l33nFTYFm/xetaHef+wbEKevEhEfKzp7Q94nwovNwjhteNSRL2+PjY1uYOQlv3yQ==",
+			"version": "1.8.4",
+			"resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-1.8.4.tgz",
+			"integrity": "sha512-eoyRARiaf+U90T2Bs2uJ2Zqqk/cLvQujOw42Y9ZB2eRJZoGjJd7Xjh4oKuhnuVGwy8lvMM/Ffj7I77E/CJ9drg==",
 			"requires": {
 				"@types/tunnel": "0.0.0",
 				"axios": "^0.18.0",
@@ -20,9 +20,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "11.13.7",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.7.tgz",
-					"integrity": "sha512-suFHr6hcA9mp8vFrZTgrmqW2ZU3mbWsryQtQlY/QvwTISCw7nw/j+bCQPPohqmskhmqa5wLNuMHTTsc+xf1MQg=="
+					"version": "12.0.0",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.0.tgz",
+					"integrity": "sha512-Jrb/x3HT4PTJp6a4avhmJCDEVrPdqLfl3e8GGMbpkGGdwAV5UGlIs4vVEfsHHfylZVOKZWpOqmqFH8CbfOZ6kg=="
 				},
 				"@types/tunnel": {
 					"version": "0.0.0",

--- a/libraries/botbuilder-ai/package.json
+++ b/libraries/botbuilder-ai/package.json
@@ -28,7 +28,7 @@
     "botbuilder-core": "~4.1.6",
     "html-entities": "^1.2.1",
     "moment": "^2.20.1",
-    "@azure/ms-rest-js": "~1.8.2",
+    "@azure/ms-rest-js": "~1.8.4",
     "request": "^2.87.0",
     "request-promise-native": "1.0.5",
     "url-parse": "^1.4.4"


### PR DESCRIPTION
Fixes #45 

## Description
Update `@azure/ms-rest-js` library in `botbuilder-ai` from version `1.8.2` to `1.8.4`(latest). This is a required change because the `@azure/cognitiveservices-luis-runtime` library is using this version and they are not compatible. 

We would also suggest changing the package version from `~1.8.4`(1.8.x) to `^1.8.4`(1.x) to provide the same compatibility as  `@azure/cognitiveservices-luis-runtime`. If we don't we may have issues if a new minor version is released. Also, we should remove `@azure/ms-rest-js` from the `package-lock.json` cause with every patch release the build may break, as `@azure/cognitiveservices-luis-runtime` is always updating to the last version.

## Specific Changes
 - change package.json to use @azure/ms-rest-js `1.8.4`

## Testing
Build passing:
![image](https://user-images.githubusercontent.com/42191764/57386868-aee2c200-718b-11e9-89b5-02c24667c53f.png)

Tests passing:
![image](https://user-images.githubusercontent.com/42191764/57386890-bb671a80-718b-11e9-8553-af2275362962.png)

