### PR TITLE
Update testbot to parity with DotNet

### DIFF
--- a/libraries/testbot/bots/echoBot.js
+++ b/libraries/testbot/bots/echoBot.js
@@ -1,0 +1,31 @@
+const { ActivityHandler } = require('botbuilder');
+
+class EchoBot extends ActivityHandler {
+    constructor(conversationState) {
+        super();
+        this.conversationState = conversationState;
+        this.conversationStateAccessor = this.conversationState.createProperty('test');
+        this.onMessage(async (context, next) => {
+
+            var state = await this.conversationStateAccessor.get(context, { count: 0 });
+
+            await context.sendActivity(`you said "${ context.activity.text }" ${ state.count }`);
+
+            state.count++;
+            await this.conversationState.saveChanges(context, false);
+
+            await next();
+        });
+        this.onMembersAdded(async (context, next) => {
+            const membersAdded = context.activity.membersAdded;
+            for (let cnt = 0; cnt < membersAdded.length; cnt++) {
+                if (membersAdded[cnt].id !== context.activity.recipient.id) {
+                    await context.sendActivity(`welcome ${ membersAdded[cnt].name }`);
+                }
+            }
+            await next();
+        });        
+    }
+}
+
+exports.EchoBot = EchoBot;

--- a/libraries/testbot/bots/myBot.js
+++ b/libraries/testbot/bots/myBot.js
@@ -1,6 +1,6 @@
 const { ActivityHandler } = require('botbuilder');
 
-class EchoBot extends ActivityHandler {
+class MyBot extends ActivityHandler {
     constructor(conversationState) {
         super();
         this.conversationState = conversationState;
@@ -28,4 +28,4 @@ class EchoBot extends ActivityHandler {
     }
 }
 
-exports.EchoBot = EchoBot;
+exports.MyBot = MyBot;

--- a/libraries/testbot/index.js
+++ b/libraries/testbot/index.js
@@ -3,7 +3,8 @@
 
 const restify = require('restify');
 
-const { BotFrameworkAdapter, ActivityHandler, MemoryStorage, UserState, ConversationState, InspectionState, InspectionMiddleware } = require('botbuilder');
+const { BotFrameworkAdapter, MemoryStorage, UserState, ConversationState, InspectionState, InspectionMiddleware } = require('botbuilder');
+const { EchoBot } = require('./bots/echoBot')
 
 const adapter = new BotFrameworkAdapter({
     appId: process.env.MicrosoftAppId,
@@ -16,8 +17,6 @@ var inspectionState = new InspectionState(memoryStorage);
 var userState = new UserState(memoryStorage);
 var conversationState = new ConversationState(memoryStorage);
 
-var conversationStateAccessor = conversationState.createProperty('test');
-
 adapter.use(new InspectionMiddleware(inspectionState, userState, conversationState));
 
 adapter.onTurnError = async (context, error) => {
@@ -25,39 +24,19 @@ adapter.onTurnError = async (context, error) => {
     await context.sendActivity(`Oops. Something went wrong!`);
 };
 
-class TestBot extends ActivityHandler {
-    constructor() {
-        super();
-        this.onMessage(async (context, next) => {
-
-            var state = await conversationStateAccessor.get(context, { count: 0 });
-
-            await context.sendActivity(`you said "${ context.activity.text }" ${ state.count }`);
-
-            state.count++;
-            await conversationState.saveChanges(context, false);
-
-            await next();
-        });
-        this.onMembersAdded(async (context, next) => {
-            const membersAdded = context.activity.membersAdded;
-            for (let cnt = 0; cnt < membersAdded.length; cnt++) {
-                if (membersAdded[cnt].id !== context.activity.recipient.id) {
-                    await context.sendActivity(`welcome ${ membersAdded[cnt].name }`);
-                }
-            }
-            await next();
-        });        
-    }
-}
-
-var bot = new TestBot();
+var bot = new EchoBot(conversationState);
 
 console.log('welcome to test bot - a local test tool for working with the emulator');
 
 let server = restify.createServer();
 server.listen(process.env.port || process.env.PORT || 3978, function() {
     console.log(`\n${ server.name } listening to ${ server.url }`);
+});
+
+server.post('/api/testbot', (req, res) => {
+    adapter.processActivity(req, res, async (turnContext) => {
+        await bot.run(turnContext);
+    });
 });
 
 server.post('/api/messages', (req, res) => {

--- a/libraries/testbot/index.js
+++ b/libraries/testbot/index.js
@@ -4,7 +4,7 @@
 const restify = require('restify');
 
 const { BotFrameworkAdapter, MemoryStorage, UserState, ConversationState, InspectionState, InspectionMiddleware } = require('botbuilder');
-const { EchoBot } = require('./bots/echoBot')
+const { MyBot } = require('./bots/myBot')
 
 const adapter = new BotFrameworkAdapter({
     appId: process.env.MicrosoftAppId,
@@ -24,7 +24,7 @@ adapter.onTurnError = async (context, error) => {
     await context.sendActivity(`Oops. Something went wrong!`);
 };
 
-var bot = new EchoBot(conversationState);
+var bot = new MyBot(conversationState);
 
 console.log('welcome to test bot - a local test tool for working with the emulator');
 
@@ -33,7 +33,7 @@ server.listen(process.env.port || process.env.PORT || 3978, function() {
     console.log(`\n${ server.name } listening to ${ server.url }`);
 });
 
-server.post('/api/testbot', (req, res) => {
+server.post('/api/mybot', (req, res) => {
     adapter.processActivity(req, res, async (turnContext) => {
         await bot.run(turnContext);
     });

--- a/libraries/testbot/package-lock.json
+++ b/libraries/testbot/package-lock.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@azure/ms-rest-js": {
       "version": "1.2.6",
-      "resolved": "http://bbnpm.azurewebsites.net/@azure%2fms-rest-js/-/ms-rest-js-1.2.6.tgz",
+      "resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-1.2.6.tgz",
       "integrity": "sha512-8cmDpxsQjVdveJwYKtNnkJorxEORLYJu9UHaUvLZA6yHExzDeISHAcSVWE0J05+VkJtqheVHF17M+2ro18Cdnw==",
       "requires": {
         "axios": "^0.18.0",
@@ -17,9 +17,26 @@
         "xml2js": "^0.4.19"
       }
     },
+    "@netflix/nerror": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@netflix/nerror/-/nerror-1.1.0.tgz",
+      "integrity": "sha512-VGB1t59S6j4ZuIaYc7PAtIQ1GgF8xPtwq/pl+VFoyjMP1jDcPgMWcLH9A5ZQEmj5p1CQ/ycN7kReKEny/CjJ8Q==",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "extsprintf": "^1.4.0",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "extsprintf": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.0.tgz",
+          "integrity": "sha1-4mifjzVvrWLMplo6kcXfX5VRaS8="
+        }
+      }
+    },
     "@types/filenamify": {
       "version": "2.0.2",
-      "resolved": "http://bbnpm.azurewebsites.net/@types%2ffilenamify/-/filenamify-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@types/filenamify/-/filenamify-2.0.2.tgz",
       "integrity": "sha512-/sO8rlEFYLZGjoDCIy1BmSdo+xNQbtJIgyrElZrzALolPUhBHvY/vQVGKSw4RSkREtuAv3eb6M7mDXvhpFxYbw==",
       "requires": {
         "filenamify": "*"
@@ -27,59 +44,52 @@
     },
     "@types/jsonwebtoken": {
       "version": "7.2.8",
-      "resolved": "http://bbnpm.azurewebsites.net/@types%2fjsonwebtoken/-/jsonwebtoken-7.2.8.tgz",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-7.2.8.tgz",
       "integrity": "sha512-XENN3YzEB8D6TiUww0O8SRznzy1v+77lH7UmuN54xq/IHIsyWjWOzZuFFTtoiRuaE782uAoRwBe/wwow+vQXZw==",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/node": {
-      "version": "10.14.5",
-      "resolved": "http://bbnpm.azurewebsites.net/@types%2fnode/-/node-10.14.5.tgz",
-      "integrity": "sha512-Ja7d4s0qyGFxjGeDq5S7Si25OFibSAHUi6i17UWnwNnpitADN7hah9q0Tl25gxuV5R1u2Bx+np6w4LHXfHyj/g=="
+      "version": "10.14.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.6.tgz",
+      "integrity": "sha512-Fvm24+u85lGmV4hT5G++aht2C5I4Z4dYlWZIh62FAfFO/TfzXtPpoLI6I7AuBWkIFqZCnhFOoTT7RjjaIL5Fjg=="
     },
     "asn1": {
       "version": "0.2.4",
-      "resolved": "http://bbnpm.azurewebsites.net/asn1/-/asn1-0.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "requires": {
         "safer-buffer": "~2.1.0"
       }
     },
     "assert": {
-      "version": "1.4.1",
-      "resolved": "http://bbnpm.azurewebsites.net/assert/-/assert-1.4.1.tgz",
-      "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
+      "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
       "requires": {
+        "object-assign": "^4.1.1",
         "util": "0.10.3"
       }
     },
     "assert-plus": {
       "version": "1.0.0",
-      "resolved": "http://bbnpm.azurewebsites.net/assert-plus/-/assert-plus-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "assertion-error": {
       "version": "1.1.0",
-      "resolved": "http://bbnpm.azurewebsites.net/assertion-error/-/assertion-error-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
-    },
-    "async-file": {
-      "version": "2.0.2",
-      "resolved": "http://bbnpm.azurewebsites.net/async-file/-/async-file-2.0.2.tgz",
-      "integrity": "sha1-Aq0HhWrDcX6DayCuxaTP4AxG3yM=",
-      "requires": {
-        "rimraf": "^2.5.2"
-      }
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "http://bbnpm.azurewebsites.net/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "axios": {
       "version": "0.18.0",
-      "resolved": "http://bbnpm.azurewebsites.net/axios/-/axios-0.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
       "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
       "requires": {
         "follow-redirects": "^1.3.0",
@@ -88,54 +98,55 @@
     },
     "balanced-match": {
       "version": "1.0.0",
-      "resolved": "http://bbnpm.azurewebsites.net/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "optional": true
     },
     "base64url": {
       "version": "3.0.1",
-      "resolved": "http://bbnpm.azurewebsites.net/base64url/-/base64url-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
       "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
-      "resolved": "http://bbnpm.azurewebsites.net/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "requires": {
         "tweetnacl": "^0.14.3"
       }
     },
     "botbuilder": {
-      "version": "4.3.4",
-      "resolved": "http://bbnpm.azurewebsites.net/botbuilder/-/botbuilder-4.3.4.tgz",
-      "integrity": "sha512-7EizagbDXGKCwHlQi0ICp1UpjBXxlha2c67y1XxaXzORWJyCTmd8HNP2iFdnxsZUGluh90jgN4C1hmJLBzSCUw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/botbuilder/-/botbuilder-4.4.0.tgz",
+      "integrity": "sha512-M3CIDjAwkOKjcxas7EahZujEIdVPc1BWS+l52DD9WNc8OL9cRMMnYVxNOCmT50CoyJ9MSEYYLJi0X3B3TVhOvQ==",
       "requires": {
         "@types/filenamify": "^2.0.1",
         "@types/node": "^10.12.18",
-        "async-file": "^2.0.2",
-        "botbuilder-core": "^4.3.4",
-        "botframework-connector": "^4.3.4",
-        "filenamify": "^2.0.0"
+        "botbuilder-core": "^4.4.0",
+        "botframework-connector": "^4.4.0",
+        "filenamify": "^2.0.0",
+        "fs-extra": "^7.0.1"
       }
     },
     "botbuilder-core": {
-      "version": "4.3.4",
-      "resolved": "http://bbnpm.azurewebsites.net/botbuilder-core/-/botbuilder-core-4.3.4.tgz",
-      "integrity": "sha512-azpPzGns88F3QIBMZw9UOn/DS/xo1odcbZq2GQkKXXQ4DxsE0xDmYUCW4rt/PuFbmB7c+GlQ8GyQZPFBI1xOHA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/botbuilder-core/-/botbuilder-core-4.4.0.tgz",
+      "integrity": "sha512-j2UdMhPTci1Go+Onr0jIN0PGn3TmWbQTyp+5qN+ffwc03MWcPiemV8d/+k8m8ewn59Q1h3u0aEQ4JiKR6egGQA==",
       "requires": {
         "assert": "^1.4.1",
-        "botframework-schema": "^4.3.4"
+        "botframework-schema": "^4.4.0"
       }
     },
     "botframework-connector": {
-      "version": "4.3.4",
-      "resolved": "http://bbnpm.azurewebsites.net/botframework-connector/-/botframework-connector-4.3.4.tgz",
-      "integrity": "sha512-aaUHVcgX1m1uwBNxdD5UrNo1f5t7zHDM/h6ha8wJMBqzwc7KXklTwagZccsw18NA1v5g5hVB8S2WgVXCeumXLg==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/botframework-connector/-/botframework-connector-4.4.0.tgz",
+      "integrity": "sha512-BXI6wyQE9aqpfWkGNBmD9/M7rk+fXIMII+1iKu1FD9bsxSiJvuvq1wz5pCmzhRjfB3hjg8114V3tZHvMPFEErg==",
       "requires": {
         "@azure/ms-rest-js": "1.2.6",
         "@types/jsonwebtoken": "7.2.8",
         "@types/node": "^10.12.18",
         "base64url": "^3.0.0",
-        "botframework-schema": "^4.3.4",
+        "botframework-schema": "^4.4.0",
         "form-data": "^2.3.3",
         "jsonwebtoken": "8.0.1",
         "nock": "^10.0.3",
@@ -144,14 +155,15 @@
       }
     },
     "botframework-schema": {
-      "version": "4.3.4",
-      "resolved": "http://bbnpm.azurewebsites.net/botframework-schema/-/botframework-schema-4.3.4.tgz",
-      "integrity": "sha512-8t+pyoMC1zN0w223SLh+qFe19ILYxcC12VPRRPXS8dydFqnCf8nV+SOpXoVFsx0eaKIhWXe868olz+Ms3ihTkA=="
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/botframework-schema/-/botframework-schema-4.4.0.tgz",
+      "integrity": "sha512-3BWQEbArzHkw49BCdyNxqmSnLzkrL396Q0c+VcdabT3t75wV+dc4bwzSBuLfG0KW+fBjhSR4BXM8IQfnIZU0Vg=="
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "resolved": "http://bbnpm.azurewebsites.net/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "optional": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -159,12 +171,12 @@
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
-      "resolved": "http://bbnpm.azurewebsites.net/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "bunyan": {
       "version": "1.8.12",
-      "resolved": "http://bbnpm.azurewebsites.net/bunyan/-/bunyan-1.8.12.tgz",
+      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.12.tgz",
       "integrity": "sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=",
       "requires": {
         "dtrace-provider": "~0.8",
@@ -175,7 +187,7 @@
     },
     "chai": {
       "version": "4.2.0",
-      "resolved": "http://bbnpm.azurewebsites.net/chai/-/chai-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
       "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
       "requires": {
         "assertion-error": "^1.1.0",
@@ -188,30 +200,31 @@
     },
     "check-error": {
       "version": "1.0.2",
-      "resolved": "http://bbnpm.azurewebsites.net/check-error/-/check-error-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
     },
     "combined-stream": {
-      "version": "1.0.7",
-      "resolved": "http://bbnpm.azurewebsites.net/combined-stream/-/combined-stream-1.0.7.tgz",
-      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "requires": {
         "delayed-stream": "~1.0.0"
       }
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "http://bbnpm.azurewebsites.net/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "optional": true
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "http://bbnpm.azurewebsites.net/core-util-is/-/core-util-is-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "csv": {
       "version": "5.1.1",
-      "resolved": "http://bbnpm.azurewebsites.net/csv/-/csv-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/csv/-/csv-5.1.1.tgz",
       "integrity": "sha512-gezB9D+enrh2tLj+vsAD8JyYRMIJdSMpec/Pgbb+7YRj6Q6/D12HLSwjhx+CrirRT4dESjZYXWX1JfqlV4RlTA==",
       "requires": {
         "csv-generate": "^3.2.0",
@@ -221,18 +234,18 @@
       }
     },
     "csv-generate": {
-      "version": "3.2.0",
-      "resolved": "http://bbnpm.azurewebsites.net/csv-generate/-/csv-generate-3.2.0.tgz",
-      "integrity": "sha512-ZdS2KrgoLxm1guL9XhuaZX223Tiorldvl9QC0M/gihcrJavNDokAp/rX3CyyRHpK+rImxEE3L47cHe7npQMkkg=="
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-3.2.3.tgz",
+      "integrity": "sha512-IcR3K0Nx+nJAkcU2eAglVR7DuHnxcuhUM2w2cR+aHOW7bZp2S5LyN2HF3zTkp6BV/DjR6ykoKznUm+AjnWcOKg=="
     },
     "csv-parse": {
       "version": "4.4.1",
-      "resolved": "http://bbnpm.azurewebsites.net/csv-parse/-/csv-parse-4.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.4.1.tgz",
       "integrity": "sha512-uFe5phPfmwBXSPWz5GYHeaEc2Oezn2kY5iLIvG1sJjc32Y4GU7T/b/uX5ffZh4CBDWwJQjwAuxrDEdl3Z5Qv+g=="
     },
     "csv-stringify": {
       "version": "5.3.0",
-      "resolved": "http://bbnpm.azurewebsites.net/csv-stringify/-/csv-stringify-5.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.3.0.tgz",
       "integrity": "sha512-VMYPbE8zWz475smwqb9VbX9cj0y4J0PBl59UdcqzLkzXHZZ8dh4Rmbb0ZywsWEtUml4A96Hn7Q5MW9ppVghYzg==",
       "requires": {
         "lodash.get": "~4.4.2"
@@ -240,7 +253,7 @@
     },
     "dashdash": {
       "version": "1.14.1",
-      "resolved": "http://bbnpm.azurewebsites.net/dashdash/-/dashdash-1.14.1.tgz",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
         "assert-plus": "^1.0.0"
@@ -248,7 +261,7 @@
     },
     "debug": {
       "version": "3.2.6",
-      "resolved": "http://bbnpm.azurewebsites.net/debug/-/debug-3.2.6.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
       "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
       "requires": {
         "ms": "^2.1.1"
@@ -256,7 +269,7 @@
     },
     "deep-eql": {
       "version": "3.0.1",
-      "resolved": "http://bbnpm.azurewebsites.net/deep-eql/-/deep-eql-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "requires": {
         "type-detect": "^4.0.0"
@@ -264,32 +277,32 @@
     },
     "deep-equal": {
       "version": "1.0.1",
-      "resolved": "http://bbnpm.azurewebsites.net/deep-equal/-/deep-equal-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
       "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "http://bbnpm.azurewebsites.net/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
       "version": "1.1.2",
-      "resolved": "http://bbnpm.azurewebsites.net/depd/-/depd-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "destroy": {
       "version": "1.0.4",
-      "resolved": "http://bbnpm.azurewebsites.net/destroy/-/destroy-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "detect-node": {
       "version": "2.0.4",
-      "resolved": "http://bbnpm.azurewebsites.net/detect-node/-/detect-node-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
       "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
     },
     "dtrace-provider": {
       "version": "0.8.7",
-      "resolved": "http://bbnpm.azurewebsites.net/dtrace-provider/-/dtrace-provider-0.8.7.tgz",
+      "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.7.tgz",
       "integrity": "sha1-3JObTT4GIM/gwc2APQ0tftBP/QQ=",
       "optional": true,
       "requires": {
@@ -298,7 +311,7 @@
     },
     "ecc-jsbn": {
       "version": "0.1.2",
-      "resolved": "http://bbnpm.azurewebsites.net/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "requires": {
         "jsbn": "~0.1.0",
@@ -307,7 +320,7 @@
     },
     "ecdsa-sig-formatter": {
       "version": "1.0.11",
-      "resolved": "http://bbnpm.azurewebsites.net/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "requires": {
         "safe-buffer": "^5.0.1"
@@ -315,37 +328,37 @@
     },
     "ee-first": {
       "version": "1.1.1",
-      "resolved": "http://bbnpm.azurewebsites.net/ee-first/-/ee-first-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "encodeurl": {
       "version": "1.0.2",
-      "resolved": "http://bbnpm.azurewebsites.net/encodeurl/-/encodeurl-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "escape-html": {
       "version": "1.0.3",
-      "resolved": "http://bbnpm.azurewebsites.net/escape-html/-/escape-html-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-regexp-component": {
       "version": "1.0.2",
-      "resolved": "http://bbnpm.azurewebsites.net/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz",
       "integrity": "sha1-nGO20LJf8qiMOtvRjFthrMO5+qI="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "http://bbnpm.azurewebsites.net/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "etag": {
       "version": "1.8.1",
-      "resolved": "http://bbnpm.azurewebsites.net/etag/-/etag-1.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "ewma": {
       "version": "2.0.1",
-      "resolved": "http://bbnpm.azurewebsites.net/ewma/-/ewma-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ewma/-/ewma-2.0.1.tgz",
       "integrity": "sha512-MYYK17A76cuuyvkR7MnqLW4iFYPEi5Isl2qb8rXiWpLiwFS9dxW/rncuNnjjgSENuVqZQkIuR4+DChVL4g1lnw==",
       "requires": {
         "assert-plus": "^1.0.0"
@@ -353,22 +366,22 @@
     },
     "extsprintf": {
       "version": "1.3.0",
-      "resolved": "http://bbnpm.azurewebsites.net/extsprintf/-/extsprintf-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-decode-uri-component": {
       "version": "1.0.1",
-      "resolved": "http://bbnpm.azurewebsites.net/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
       "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="
     },
     "filename-reserved-regex": {
       "version": "2.0.0",
-      "resolved": "http://bbnpm.azurewebsites.net/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
       "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik="
     },
     "filenamify": {
       "version": "2.1.0",
-      "resolved": "http://bbnpm.azurewebsites.net/filenamify/-/filenamify-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-2.1.0.tgz",
       "integrity": "sha512-ICw7NTT6RsDp2rnYKVd8Fu4cr6ITzGy3+u4vUujPkabyaz+03F24NWEX7fs5fp+kBonlaqPH8fAO2NM+SXt/JA==",
       "requires": {
         "filename-reserved-regex": "^2.0.0",
@@ -378,7 +391,7 @@
     },
     "find-my-way": {
       "version": "2.0.1",
-      "resolved": "http://bbnpm.azurewebsites.net/find-my-way/-/find-my-way-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-2.0.1.tgz",
       "integrity": "sha512-c+YnWk4LKcWSNu743wfoqNOZTYQ6kZ/kzZCjALGblLpzbEAv3INakGMZ1K/by+Wmf/NP3+3LpOQMOFw6/q52wQ==",
       "requires": {
         "fast-decode-uri-component": "^1.0.0",
@@ -388,7 +401,7 @@
     },
     "follow-redirects": {
       "version": "1.7.0",
-      "resolved": "http://bbnpm.azurewebsites.net/follow-redirects/-/follow-redirects-1.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
       "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
       "requires": {
         "debug": "^3.2.6"
@@ -396,7 +409,7 @@
     },
     "form-data": {
       "version": "2.3.3",
-      "resolved": "http://bbnpm.azurewebsites.net/form-data/-/form-data-2.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "requires": {
         "asynckit": "^0.4.0",
@@ -406,53 +419,63 @@
     },
     "formidable": {
       "version": "1.2.1",
-      "resolved": "http://bbnpm.azurewebsites.net/formidable/-/formidable-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
       "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
     },
     "fresh": {
       "version": "0.5.2",
-      "resolved": "http://bbnpm.azurewebsites.net/fresh/-/fresh-0.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
-    "fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "http://bbnpm.azurewebsites.net/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    "fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
     },
     "get-func-name": {
       "version": "2.0.0",
-      "resolved": "http://bbnpm.azurewebsites.net/get-func-name/-/get-func-name-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
     },
     "getpass": {
       "version": "0.1.7",
-      "resolved": "http://bbnpm.azurewebsites.net/getpass/-/getpass-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
         "assert-plus": "^1.0.0"
       }
     },
     "glob": {
-      "version": "7.1.3",
-      "resolved": "http://bbnpm.azurewebsites.net/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+      "optional": true,
       "requires": {
-        "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "2 || 3",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
     },
+    "graceful-fs": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
+    },
     "handle-thing": {
       "version": "2.0.0",
-      "resolved": "http://bbnpm.azurewebsites.net/handle-thing/-/handle-thing-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.0.tgz",
       "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ=="
     },
     "hpack.js": {
       "version": "2.1.6",
-      "resolved": "http://bbnpm.azurewebsites.net/hpack.js/-/hpack.js-2.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
       "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
       "requires": {
         "inherits": "^2.0.1",
@@ -463,7 +486,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://bbnpm.azurewebsites.net/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -473,29 +496,43 @@
             "safe-buffer": "~5.1.1",
             "string_decoder": "~1.1.1",
             "util-deprecate": "~1.0.1"
+          },
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+            }
           }
         }
       }
     },
     "http-deceiver": {
       "version": "1.2.7",
-      "resolved": "http://bbnpm.azurewebsites.net/http-deceiver/-/http-deceiver-1.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
       "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc="
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "http://bbnpm.azurewebsites.net/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
         "depd": "~1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
         "statuses": ">= 1.4.0 < 2"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        }
       }
     },
     "http-signature": {
       "version": "1.2.0",
-      "resolved": "http://bbnpm.azurewebsites.net/http-signature/-/http-signature-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
         "assert-plus": "^1.0.0",
@@ -505,46 +542,55 @@
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "http://bbnpm.azurewebsites.net/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "optional": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "http://bbnpm.azurewebsites.net/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
     },
     "is-buffer": {
       "version": "1.1.6",
-      "resolved": "http://bbnpm.azurewebsites.net/is-buffer/-/is-buffer-1.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "isarray": {
       "version": "1.0.0",
-      "resolved": "http://bbnpm.azurewebsites.net/isarray/-/isarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "jsbn": {
       "version": "0.1.1",
-      "resolved": "http://bbnpm.azurewebsites.net/jsbn/-/jsbn-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "json-schema": {
       "version": "0.2.3",
-      "resolved": "http://bbnpm.azurewebsites.net/json-schema/-/json-schema-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "http://bbnpm.azurewebsites.net/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "jsonwebtoken": {
       "version": "8.0.1",
-      "resolved": "http://bbnpm.azurewebsites.net/jsonwebtoken/-/jsonwebtoken-8.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.0.1.tgz",
       "integrity": "sha1-UNrvjQqMfeLNBrwQE7dbBMzz8M8=",
       "requires": {
         "jws": "^3.1.4",
@@ -561,7 +607,7 @@
     },
     "jsprim": {
       "version": "1.4.1",
-      "resolved": "http://bbnpm.azurewebsites.net/jsprim/-/jsprim-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "requires": {
         "assert-plus": "1.0.0",
@@ -572,7 +618,7 @@
     },
     "jwa": {
       "version": "1.4.1",
-      "resolved": "http://bbnpm.azurewebsites.net/jwa/-/jwa-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
       "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
@@ -582,7 +628,7 @@
     },
     "jws": {
       "version": "3.2.2",
-      "resolved": "http://bbnpm.azurewebsites.net/jws/-/jws-3.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
       "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
       "requires": {
         "jwa": "^1.4.1",
@@ -591,70 +637,70 @@
     },
     "lodash": {
       "version": "4.17.11",
-      "resolved": "http://bbnpm.azurewebsites.net/lodash/-/lodash-4.17.11.tgz",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash.get": {
       "version": "4.4.2",
-      "resolved": "http://bbnpm.azurewebsites.net/lodash.get/-/lodash.get-4.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.includes": {
       "version": "4.3.0",
-      "resolved": "http://bbnpm.azurewebsites.net/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
     },
     "lodash.isboolean": {
       "version": "3.0.3",
-      "resolved": "http://bbnpm.azurewebsites.net/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
     },
     "lodash.isinteger": {
       "version": "4.0.4",
-      "resolved": "http://bbnpm.azurewebsites.net/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
       "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
     },
     "lodash.isnumber": {
       "version": "3.0.3",
-      "resolved": "http://bbnpm.azurewebsites.net/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
       "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
-      "resolved": "http://bbnpm.azurewebsites.net/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
     },
     "lodash.isstring": {
       "version": "4.0.1",
-      "resolved": "http://bbnpm.azurewebsites.net/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
     "lodash.once": {
       "version": "4.1.1",
-      "resolved": "http://bbnpm.azurewebsites.net/lodash.once/-/lodash.once-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "lru-cache": {
       "version": "5.1.1",
-      "resolved": "http://bbnpm.azurewebsites.net/lru-cache/-/lru-cache-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "requires": {
         "yallist": "^3.0.2"
       }
     },
     "mime": {
-      "version": "2.4.2",
-      "resolved": "http://bbnpm.azurewebsites.net/mime/-/mime-2.4.2.tgz",
-      "integrity": "sha512-zJBfZDkwRu+j3Pdd2aHsR5GfH2jIWhmL1ZzBoc+X+3JEti2hbArWcyJ+1laC1D2/U/W1a/+Cegj0/OnEU2ybjg=="
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.3.tgz",
+      "integrity": "sha512-QgrPRJfE+riq5TPZMcHZOtm8c6K/yYrMbKIoRfapfiGLxS8OTeIfRhUGW5LU7MlRa52KOAGCfUNruqLrIBvWZw=="
     },
     "mime-db": {
       "version": "1.40.0",
-      "resolved": "http://bbnpm.azurewebsites.net/mime-db/-/mime-db-1.40.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
       "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
     },
     "mime-types": {
       "version": "2.1.24",
-      "resolved": "http://bbnpm.azurewebsites.net/mime-types/-/mime-types-2.1.24.tgz",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
       "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
       "requires": {
         "mime-db": "1.40.0"
@@ -662,25 +708,26 @@
     },
     "minimalistic-assert": {
       "version": "1.0.1",
-      "resolved": "http://bbnpm.azurewebsites.net/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
       "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "minimatch": {
       "version": "3.0.4",
-      "resolved": "http://bbnpm.azurewebsites.net/minimatch/-/minimatch-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "optional": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://bbnpm.azurewebsites.net/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://bbnpm.azurewebsites.net/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -688,70 +735,46 @@
     },
     "moment": {
       "version": "2.24.0",
-      "resolved": "http://bbnpm.azurewebsites.net/moment/-/moment-2.24.0.tgz",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
       "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
       "optional": true
     },
     "ms": {
       "version": "2.1.1",
-      "resolved": "http://bbnpm.azurewebsites.net/ms/-/ms-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "mv": {
       "version": "2.1.1",
-      "resolved": "http://bbnpm.azurewebsites.net/mv/-/mv-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
       "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
       "optional": true,
       "requires": {
         "mkdirp": "~0.5.1",
         "ncp": "~2.0.0",
         "rimraf": "~2.4.0"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "6.0.4",
-          "resolved": "http://bbnpm.azurewebsites.net/glob/-/glob-6.0.4.tgz",
-          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-          "optional": true,
-          "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "rimraf": {
-          "version": "2.4.5",
-          "resolved": "http://bbnpm.azurewebsites.net/rimraf/-/rimraf-2.4.5.tgz",
-          "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
-          "optional": true,
-          "requires": {
-            "glob": "^6.0.1"
-          }
-        }
       }
     },
     "nan": {
-      "version": "2.13.2",
-      "resolved": "http://bbnpm.azurewebsites.net/nan/-/nan-2.13.2.tgz",
-      "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
       "optional": true
     },
     "ncp": {
       "version": "2.0.0",
-      "resolved": "http://bbnpm.azurewebsites.net/ncp/-/ncp-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
       "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
       "optional": true
     },
     "negotiator": {
-      "version": "0.6.1",
-      "resolved": "http://bbnpm.azurewebsites.net/negotiator/-/negotiator-0.6.1.tgz",
-      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
     "nock": {
       "version": "10.0.6",
-      "resolved": "http://bbnpm.azurewebsites.net/nock/-/nock-10.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-10.0.6.tgz",
       "integrity": "sha512-b47OWj1qf/LqSQYnmokNWM8D88KvUl2y7jT0567NB3ZBAZFz2bWp2PC81Xn7u8F2/vJxzkzNZybnemeFa7AZ2w==",
       "requires": {
         "chai": "^4.1.2",
@@ -767,7 +790,7 @@
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "http://bbnpm.azurewebsites.net/debug/-/debug-4.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
             "ms": "^2.1.1"
@@ -776,18 +799,23 @@
       }
     },
     "node-fetch": {
-      "version": "2.3.0",
-      "resolved": "http://bbnpm.azurewebsites.net/node-fetch/-/node-fetch-2.3.0.tgz",
-      "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "obuf": {
       "version": "1.1.2",
-      "resolved": "http://bbnpm.azurewebsites.net/obuf/-/obuf-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
     },
     "on-finished": {
       "version": "2.3.0",
-      "resolved": "http://bbnpm.azurewebsites.net/on-finished/-/on-finished-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
       "requires": {
         "ee-first": "1.1.1"
@@ -795,7 +823,7 @@
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "http://bbnpm.azurewebsites.net/once/-/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
@@ -803,17 +831,18 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://bbnpm.azurewebsites.net/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "optional": true
     },
     "pathval": {
       "version": "1.1.0",
-      "resolved": "http://bbnpm.azurewebsites.net/pathval/-/pathval-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
     },
     "pidusage": {
       "version": "2.0.17",
-      "resolved": "http://bbnpm.azurewebsites.net/pidusage/-/pidusage-2.0.17.tgz",
+      "resolved": "https://registry.npmjs.org/pidusage/-/pidusage-2.0.17.tgz",
       "integrity": "sha512-N8X5v18rBmlBoArfS83vrnD0gIFyZkXEo7a5pAS2aT0i2OLVymFb2AzVg+v8l/QcXnE1JwZcaXR8daJcoJqtjw==",
       "requires": {
         "safe-buffer": "^5.1.2"
@@ -821,48 +850,55 @@
     },
     "process-nextick-args": {
       "version": "2.0.0",
-      "resolved": "http://bbnpm.azurewebsites.net/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "propagate": {
       "version": "1.0.0",
-      "resolved": "http://bbnpm.azurewebsites.net/propagate/-/propagate-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
       "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk="
     },
     "psl": {
       "version": "1.1.31",
-      "resolved": "http://bbnpm.azurewebsites.net/psl/-/psl-1.1.31.tgz",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
       "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
     },
     "punycode": {
       "version": "2.1.1",
-      "resolved": "http://bbnpm.azurewebsites.net/punycode/-/punycode-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.7.0",
-      "resolved": "http://bbnpm.azurewebsites.net/qs/-/qs-6.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
     },
     "range-parser": {
-      "version": "1.2.0",
-      "resolved": "http://bbnpm.azurewebsites.net/range-parser/-/range-parser-1.2.0.tgz",
-      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "readable-stream": {
       "version": "3.3.0",
-      "resolved": "http://bbnpm.azurewebsites.net/readable-stream/-/readable-stream-3.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
       "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
         "util-deprecate": "^1.0.1"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        }
       }
     },
     "restify": {
-      "version": "8.3.0",
-      "resolved": "http://bbnpm.azurewebsites.net/restify/-/restify-8.3.0.tgz",
-      "integrity": "sha512-6SJg/x2Idwm/mNgieNK5WRuafIfEf+7xuSfwzY2lO1B4278CT86sjM1JF2Sgs4k3vLM/ZWdoYFvQm7lqcJIq1w==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/restify/-/restify-8.3.2.tgz",
+      "integrity": "sha512-ktp5/sB9VUENH/BtWck5Z5uZd4HsqhJV4vK0jtKObOP4Oib49CsJ2ju/VHRVEk/+7lepjOqr3ufrhvJGBC5B3g==",
       "requires": {
         "assert-plus": "^1.0.0",
         "bunyan": "^1.8.12",
@@ -880,58 +916,58 @@
         "once": "^1.4.0",
         "pidusage": "^2.0.17",
         "qs": "^6.5.2",
-        "restify-errors": "^7.0.0",
+        "restify-errors": "^8.0.0",
         "semver": "^5.4.1",
         "send": "^0.16.2",
         "spdy": "^4.0.0",
         "uuid": "^3.1.0",
-        "vasync": "^2.2.0",
-        "verror": "^1.10.0"
+        "vasync": "^2.2.0"
       }
     },
     "restify-errors": {
-      "version": "7.0.0",
-      "resolved": "http://bbnpm.azurewebsites.net/restify-errors/-/restify-errors-7.0.0.tgz",
-      "integrity": "sha512-2XWkUSd82tMQQY/Ufdmfp+KFfhd2bMAqN4s1EAsfj1Ir3RmyKB6i0r8wcVDJm/CR+tDfeYN8vCKgqH5yEhcF6w==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/restify-errors/-/restify-errors-8.0.0.tgz",
+      "integrity": "sha512-UpY727sc65Zuz0vBS3Pk3wU4UD1HluIwNRINlPaA/dxLzmf2RlzH/gqZUne9X+MO48cn+DVL7SleDG+9V5YzYQ==",
       "requires": {
+        "@netflix/nerror": "^1.0.0",
         "assert-plus": "^1.0.0",
-        "lodash": "^4.17.4",
-        "safe-json-stringify": "^1.0.4",
-        "verror": "^1.10.0"
+        "lodash": "^4.17.11",
+        "safe-json-stringify": "^1.0.4"
       }
     },
     "ret": {
       "version": "0.2.2",
-      "resolved": "http://bbnpm.azurewebsites.net/ret/-/ret-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
       "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ=="
     },
     "rimraf": {
-      "version": "2.6.3",
-      "resolved": "http://bbnpm.azurewebsites.net/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+      "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
+      "optional": true,
       "requires": {
-        "glob": "^7.1.3"
+        "glob": "^6.0.1"
       }
     },
     "rsa-pem-from-mod-exp": {
       "version": "0.8.4",
-      "resolved": "http://bbnpm.azurewebsites.net/rsa-pem-from-mod-exp/-/rsa-pem-from-mod-exp-0.8.4.tgz",
+      "resolved": "https://registry.npmjs.org/rsa-pem-from-mod-exp/-/rsa-pem-from-mod-exp-0.8.4.tgz",
       "integrity": "sha1-NipCxtMEBW1JOz8SvOq7LGV2ptQ="
     },
     "safe-buffer": {
       "version": "5.1.2",
-      "resolved": "http://bbnpm.azurewebsites.net/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safe-json-stringify": {
       "version": "1.2.0",
-      "resolved": "http://bbnpm.azurewebsites.net/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
       "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
       "optional": true
     },
     "safe-regex2": {
       "version": "2.0.0",
-      "resolved": "http://bbnpm.azurewebsites.net/safe-regex2/-/safe-regex2-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-2.0.0.tgz",
       "integrity": "sha512-PaUSFsUaNNuKwkBijoAPHAK6/eM6VirvyPWlZ7BAQy4D+hCvh4B6lIG+nPdhbFfIbP+gTGBcrdsOaUs0F+ZBOQ==",
       "requires": {
         "ret": "~0.2.0"
@@ -939,32 +975,32 @@
     },
     "safer-buffer": {
       "version": "2.1.2",
-      "resolved": "http://bbnpm.azurewebsites.net/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sax": {
       "version": "1.2.4",
-      "resolved": "http://bbnpm.azurewebsites.net/sax/-/sax-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "select-hose": {
       "version": "2.0.0",
-      "resolved": "http://bbnpm.azurewebsites.net/select-hose/-/select-hose-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
     },
     "semver": {
       "version": "5.7.0",
-      "resolved": "http://bbnpm.azurewebsites.net/semver/-/semver-5.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
       "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
     },
     "semver-store": {
       "version": "0.3.0",
-      "resolved": "http://bbnpm.azurewebsites.net/semver-store/-/semver-store-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/semver-store/-/semver-store-0.3.0.tgz",
       "integrity": "sha512-TcZvGMMy9vodEFSse30lWinkj+JgOBvPn8wRItpQRSayhc+4ssDs335uklkfvQQJgL/WvmHLVj4Ycv2s7QCQMg=="
     },
     "send": {
       "version": "0.16.2",
-      "resolved": "http://bbnpm.azurewebsites.net/send/-/send-0.16.2.tgz",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
       "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
       "requires": {
         "debug": "2.6.9",
@@ -984,7 +1020,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://bbnpm.azurewebsites.net/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
@@ -992,24 +1028,24 @@
         },
         "mime": {
           "version": "1.4.1",
-          "resolved": "http://bbnpm.azurewebsites.net/mime/-/mime-1.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
           "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "http://bbnpm.azurewebsites.net/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
     "setprototypeof": {
       "version": "1.1.0",
-      "resolved": "http://bbnpm.azurewebsites.net/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
       "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
     },
     "spdy": {
       "version": "4.0.0",
-      "resolved": "http://bbnpm.azurewebsites.net/spdy/-/spdy-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.0.tgz",
       "integrity": "sha512-ot0oEGT/PGUpzf/6uk4AWLqkq+irlqHXkrdbk51oWONh3bxQmBuljxPNl66zlRRcIJStWq0QkLUCPOPjgjvU0Q==",
       "requires": {
         "debug": "^4.1.0",
@@ -1021,7 +1057,7 @@
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "http://bbnpm.azurewebsites.net/debug/-/debug-4.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
             "ms": "^2.1.1"
@@ -1031,7 +1067,7 @@
     },
     "spdy-transport": {
       "version": "3.0.0",
-      "resolved": "http://bbnpm.azurewebsites.net/spdy-transport/-/spdy-transport-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-3.0.0.tgz",
       "integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
       "requires": {
         "debug": "^4.1.0",
@@ -1044,7 +1080,7 @@
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "http://bbnpm.azurewebsites.net/debug/-/debug-4.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
             "ms": "^2.1.1"
@@ -1054,7 +1090,7 @@
     },
     "sshpk": {
       "version": "1.16.1",
-      "resolved": "http://bbnpm.azurewebsites.net/sshpk/-/sshpk-1.16.1.tgz",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "requires": {
         "asn1": "~0.2.3",
@@ -1070,17 +1106,17 @@
     },
     "statuses": {
       "version": "1.4.0",
-      "resolved": "http://bbnpm.azurewebsites.net/statuses/-/statuses-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
       "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
     },
     "stream-transform": {
       "version": "1.0.8",
-      "resolved": "http://bbnpm.azurewebsites.net/stream-transform/-/stream-transform-1.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-1.0.8.tgz",
       "integrity": "sha512-1q+dL790Ps0NV33rISMq9OLtfDA9KMJZdo1PHZXE85orrWsM4FAh8CVyAOTHO0rhyeM138KNPngBPrx33bFsxw=="
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "http://bbnpm.azurewebsites.net/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "~5.1.0"
@@ -1088,7 +1124,7 @@
     },
     "strip-outer": {
       "version": "1.0.1",
-      "resolved": "http://bbnpm.azurewebsites.net/strip-outer/-/strip-outer-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
       "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
       "requires": {
         "escape-string-regexp": "^1.0.2"
@@ -1096,7 +1132,7 @@
     },
     "tough-cookie": {
       "version": "2.5.0",
-      "resolved": "http://bbnpm.azurewebsites.net/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "requires": {
         "psl": "^1.1.28",
@@ -1105,7 +1141,7 @@
     },
     "trim-repeated": {
       "version": "1.0.0",
-      "resolved": "http://bbnpm.azurewebsites.net/trim-repeated/-/trim-repeated-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
       "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
       "requires": {
         "escape-string-regexp": "^1.0.2"
@@ -1113,47 +1149,45 @@
     },
     "tslib": {
       "version": "1.9.3",
-      "resolved": "http://bbnpm.azurewebsites.net/tslib/-/tslib-1.9.3.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
       "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "resolved": "http://bbnpm.azurewebsites.net/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-detect": {
       "version": "4.0.8",
-      "resolved": "http://bbnpm.azurewebsites.net/type-detect/-/type-detect-4.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "util": {
       "version": "0.10.3",
-      "resolved": "http://bbnpm.azurewebsites.net/util/-/util-0.10.3.tgz",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
       "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
       "requires": {
         "inherits": "2.0.1"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.1",
-          "resolved": "http://bbnpm.azurewebsites.net/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
-        }
       }
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "http://bbnpm.azurewebsites.net/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "3.3.2",
-      "resolved": "http://bbnpm.azurewebsites.net/uuid/-/uuid-3.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "vasync": {
       "version": "2.2.0",
-      "resolved": "http://bbnpm.azurewebsites.net/vasync/-/vasync-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/vasync/-/vasync-2.2.0.tgz",
       "integrity": "sha1-z951GGChWCLbOxMrxZsRakra8Bs=",
       "requires": {
         "verror": "1.10.0"
@@ -1161,7 +1195,7 @@
     },
     "verror": {
       "version": "1.10.0",
-      "resolved": "http://bbnpm.azurewebsites.net/verror/-/verror-1.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
         "assert-plus": "^1.0.0",
@@ -1171,7 +1205,7 @@
     },
     "wbuf": {
       "version": "1.7.3",
-      "resolved": "http://bbnpm.azurewebsites.net/wbuf/-/wbuf-1.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
       "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
       "requires": {
         "minimalistic-assert": "^1.0.0"
@@ -1179,12 +1213,12 @@
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "http://bbnpm.azurewebsites.net/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "xml2js": {
       "version": "0.4.19",
-      "resolved": "http://bbnpm.azurewebsites.net/xml2js/-/xml2js-0.4.19.tgz",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "requires": {
         "sax": ">=0.6.0",
@@ -1193,17 +1227,17 @@
     },
     "xmlbuilder": {
       "version": "9.0.7",
-      "resolved": "http://bbnpm.azurewebsites.net/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xtend": {
       "version": "4.0.1",
-      "resolved": "http://bbnpm.azurewebsites.net/xtend/-/xtend-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "yallist": {
       "version": "3.0.3",
-      "resolved": "http://bbnpm.azurewebsites.net/yallist/-/yallist-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
       "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
     }
   }


### PR DESCRIPTION
## Description
We updated the testbot project to have parity with the Botbuilder-DotNet implementation in the [PR#1946](https://github.com/microsoft/botbuilder-dotnet/pull/1946) that configured an endpoint for each bot in the testbot project. To do that, we separated the bot logic from index.js file and added a new post method with the route '/api/testbot' to handle the messages sent to the testbot.

Additionally, we updated the package-lock.json to get the latest version of the botbuilder libraries.

## Specific Changes

- Separate the bot logic from the index.js file
- Update the package-lock.json

## Testing
![image](https://user-images.githubusercontent.com/37461749/58489088-f03e1000-8140-11e9-840e-861c433ade3c.png)
