### PR TITLE
[BotBuilder-AI] Update / Refactor luisClient.ts

### DIFF
--- a/libraries/botbuilder-ai/src/luis-client/luisClient.ts
+++ b/libraries/botbuilder-ai/src/luis-client/luisClient.ts
@@ -98,8 +98,8 @@ export class LuisClient {
      * @returns Promise<LuisResult>
      */
     public async predictionResolvePost(query: string, appId: string, options: PredictionResolveOptionalParams): Promise<LuisResult> {
-        const localVarPath = this.basePath + '/apps/{appId}'
-            .replace('{' + 'appId' + '}', encodeURIComponent(String(appId)));        
+        const path = require('path');
+        const localVarPath = path.join(this.basePath, `/apps/${String(appId)}`)     
         let localVarQueryParameters: any = {};
         let localVarHeaderParams = this.defaultHeaders
         let localVarFormParams: any = {};
@@ -200,8 +200,8 @@ export class LuisClient {
      * @returns Promise<LuisResult>
      */
     public async predictionResolveGet(appId: string, query: string, options: PredictionResolveOptionalParams): Promise<LuisResult> {
-        const localVarPath = this.basePath + '/apps/{appId}'
-            .replace('{' + 'appId' + '}', encodeURIComponent(String(appId)));
+        const path = require('path');
+        const localVarPath = path.join(this.basePath, `/apps/${String(appId)}`)        
         let localVarQueryParameters: any = {};
         let localVarHeaderParams = (Object as any).assign({}, this.defaultHeaders) as any;
         let localVarFormParams: any = {};

--- a/libraries/botbuilder-ai/src/luis-client/luisClient.ts
+++ b/libraries/botbuilder-ai/src/luis-client/luisClient.ts
@@ -90,6 +90,15 @@ export class LuisClient {
         (this.authentications as any)[LuisApikeys[key]].apiKey = value;
     }
 
+    /** 
+     * Returns the local URL
+     * @param appId The appId.
+     * @returns String
+    */
+    private getLocalURL(appId: string): string {
+        return this.basePath + '/apps/' + encodeURIComponent(appId); 
+    }
+
     /**
      * Gets predictions for a given utterance, in the form of intents and entities. The current maximum query size is 500 characters.
      * @param query The utterance to predict.
@@ -98,8 +107,8 @@ export class LuisClient {
      * @returns Promise<LuisResult>
      */
     public async predictionResolvePost(query: string, appId: string, options: PredictionResolveOptionalParams): Promise<LuisResult> {
-        const path = require('path');
-        const localVarPath = path.join(this.basePath, `/apps/${String(appId)}`)     
+        const localVarPath = this.getLocalURL(appId);
+
         let localVarQueryParameters: any = {};
         let localVarHeaderParams = this.defaultHeaders
         let localVarFormParams: any = {};
@@ -200,8 +209,8 @@ export class LuisClient {
      * @returns Promise<LuisResult>
      */
     public async predictionResolveGet(appId: string, query: string, options: PredictionResolveOptionalParams): Promise<LuisResult> {
-        const path = require('path');
-        const localVarPath = path.join(this.basePath, `/apps/${String(appId)}`)        
+        const localVarPath = this.getLocalURL(appId);
+
         let localVarQueryParameters: any = {};
         let localVarHeaderParams = (Object as any).assign({}, this.defaultHeaders) as any;
         let localVarFormParams: any = {};


### PR DESCRIPTION
## Description
Refactor (extract method) of LuisClient.ts for simplification, increased reusability and readability.

## Specific Changes
Originally the plan was to use `path.join()` and _template literals_. However, this approach did not worked.
- `path.join()` had issues eliminating one slash in the `https://` prefix.
- As a corollary of this issue, the template literals were not necessary.

Now in the methods: 
- `predictionResolvePost`
- `predictionResolveGet` 

There is an invocation of the new private function `getLocalURL`, passing the appId as the only parameter.

signature:
`private getLocalURL(appId: string): string`

This function is very small, and takes care of using the encodeURIComponent() function internally, returning the local URL ready to use. It has several simplifications from the original code.

## Testing
The local tests passed successfully.
![image](https://user-images.githubusercontent.com/24591490/62662950-2ae7d400-b94c-11e9-81ca-489e369b53d1.png)
