### PR TITLE
[BotBuilder-AI] Replaced numbers '200' and '300' to verify the response status code with enumerated constants

### DIFF
--- a/libraries/botbuilder-ai/package.json
+++ b/libraries/botbuilder-ai/package.json
@@ -21,16 +21,17 @@
   "typings": "./lib/index.d.ts",
   "dependencies": {
     "@microsoft/recognizers-text-date-time": "1.1.2",
-    "@types/node": "^10.12.18",
-    "botbuilder-core": "4.1.6",
-    "moment": "^2.20.1",
-    "node-fetch": "^2.3.0",
-    "url-parse": "^1.4.4",
     "@types/bluebird": "^3.5.27",
+    "@types/node": "^10.12.18",
     "@types/request": "^2.48.2",
     "bluebird": "^3.5.0",
+    "botbuilder-core": "4.1.6",
+    "http-status-codes": "^1.3.2",
+    "moment": "^2.20.1",
+    "node-fetch": "^2.3.0",
     "request": "^2.81.0",
-    "rewire": "^3.0.2"
+    "rewire": "^3.0.2",
+    "url-parse": "^1.4.4"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.47",

--- a/libraries/botbuilder-ai/src/luis-client/luisClient.ts
+++ b/libraries/botbuilder-ai/src/luis-client/luisClient.ts
@@ -174,7 +174,7 @@ export class LuisClient {
                     reject(error);
                 } else {
                     luisResult = ObjectSerializer.deserialize(luisResult, 'LuisResult');
-                    if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
+                    if (response.statusCode && response.statusCode >= HttpStatus.OK && response.statusCode < HttpStatus.MULTIPLE_CHOICES) {
                         resolve(luisResult);
                     } else {
                         reject({
@@ -202,6 +202,7 @@ export class LuisClient {
     public async predictionResolveGet(appId: string, query: string, options: PredictionResolveOptionalParams): Promise<LuisResult> {
         const localVarPath = this.basePath + '/apps/{appId}'
             .replace('{' + 'appId' + '}', encodeURIComponent(String(appId)));
+        var HttpStatus = require('http-status-codes');
         let localVarQueryParameters: any = {};
         let localVarHeaderParams = (Object as any).assign({}, this.defaultHeaders) as any;
         let localVarFormParams: any = {};
@@ -280,7 +281,7 @@ export class LuisClient {
                     reject(error);
                 } else {
                     luisResult = ObjectSerializer.deserialize(luisResult, 'LuisResult');
-                    if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
+                    if (response.statusCode && response.statusCode >= HttpStatus.OK && response.statusCode < HttpStatus.MULTIPLE_CHOICES) {
                         resolve(luisResult);
                     } else {
                         reject({

--- a/libraries/botbuilder-ai/src/luis-client/luisClient.ts
+++ b/libraries/botbuilder-ai/src/luis-client/luisClient.ts
@@ -12,6 +12,7 @@
 
 import localVarRequest = require('request');
 import http = require('http');
+import * as HttpStatus from 'http-status-codes';
 
 /* tslint:disable:no-unused-locals */
 import { LuisResult } from './model/luisResult';
@@ -99,7 +100,7 @@ export class LuisClient {
      */
     public async predictionResolvePost(query: string, appId: string, options: PredictionResolveOptionalParams): Promise<LuisResult> {
         const localVarPath = this.basePath + '/apps/{appId}'
-            .replace('{' + 'appId' + '}', encodeURIComponent(String(appId)));        
+            .replace('{' + 'appId' + '}', encodeURIComponent(String(appId)));
         let localVarQueryParameters: any = {};
         let localVarHeaderParams = this.defaultHeaders
         let localVarFormParams: any = {};
@@ -202,7 +203,6 @@ export class LuisClient {
     public async predictionResolveGet(appId: string, query: string, options: PredictionResolveOptionalParams): Promise<LuisResult> {
         const localVarPath = this.basePath + '/apps/{appId}'
             .replace('{' + 'appId' + '}', encodeURIComponent(String(appId)));
-        var HttpStatus = require('http-status-codes');
         let localVarQueryParameters: any = {};
         let localVarHeaderParams = (Object as any).assign({}, this.defaultHeaders) as any;
         let localVarFormParams: any = {};


### PR DESCRIPTION
### Description
Refactor with substitution from magic numbers to enumerated constants.

### Changes made
- Added [http-status-codes](https://www.npmjs.com/package/http-status-codes)
- Replaced magic numbers '200' and '300' with enumerated constants.


### Testing
Test passed successfully.
![image](https://user-images.githubusercontent.com/24591490/62727687-60de9400-b9f0-11e9-9521-be159fa05fe3.png)
