### PR TITLE
Changed _basePath from protected to private

### DIFF
--- a/libraries/botbuilder-ai/src/luis-client/luisClient.ts
+++ b/libraries/botbuilder-ai/src/luis-client/luisClient.ts
@@ -56,7 +56,7 @@ export enum LuisApikeys {
 }
 
 export class LuisClient {
-    protected _basePath: string = '';
+    private _basePath: string = '';
     protected _useQuerystring: boolean = false;
 
     protected authentications = {
@@ -64,6 +64,9 @@ export class LuisClient {
         'apiKeyHeader': new ApiKeyAuth('header', 'Ocp-Apim-Subscription-Key'),
     }
 
+    /** Creates a new instance of LuisClient.
+     * @param basePath Acceptable values: 'https://westus.api.cognitive.microsoft.com'
+     */
     public constructor(basePath: string){
         if (basePath) {
             this._basePath = basePath + luisVersion;


### PR DESCRIPTION
## Description
The class `LuisClient` had a `protected` field (_basePath). We changed it to `private` and added documentation to the constructor. We received feedback from [stevengum](https://github.com/stevengum). More details [here](https://github.com/microsoft/botbuilder-js/pull/1107#discussion_r314857347).

## Specific Changes
Changes:
*luisClient.ts*
- Changed accesibility modifier for `_basePath` from `protected` to `private`.
- Added documentation for constructor of `LuisClient` class.

## Testing
The next image shows the result of the local tests.
![image](https://user-images.githubusercontent.com/24591490/63460539-1f58da80-c42d-11e9-827b-f35b78532423.png)
