### PR TITLE
[BotBuilder-AI] Removed useQueryString

### DIFF
--- a/libraries/botbuilder-ai/src/luis-client/luisClient.ts
+++ b/libraries/botbuilder-ai/src/luis-client/luisClient.ts
@@ -57,7 +57,6 @@ export enum LuisApikeys {
 
 export class LuisClient {
     private _basePath: string = '';
-    protected _useQuerystring: boolean = false;
 
     protected authentications = {
         'default': new VoidAuth() as Authentication,


### PR DESCRIPTION
## Description
Removed `_useQueryString` member from `LuisClient` as the _LuisClient_ class nor any other classes reference it.

## Testing
![image](https://user-images.githubusercontent.com/43762887/63461557-42848980-c42f-11e9-963b-cbcfabb77a67.png)
