### PR TITLE
[BotBuilder-AI] Add new test method for case 404

### DIFF
--- a/libraries/botbuilder-ai/tests/luisSdk.test.js
+++ b/libraries/botbuilder-ai/tests/luisSdk.test.js
@@ -162,7 +162,6 @@ const luisUri = new RegExp(pattern);
 
 function ReturnErrorStatusCode(basePath, uri, statusCode) {
     nock(basePath)        
-        .matchHeader('authorization', `Bearer ${endpointKey}`)
         .post(uri)
         .reply(statusCode);
 }


### PR DESCRIPTION
### Description

Added a new negative test for suite LuisClient to handle the expected 404 error when the server can not find the requested resource.

For example when the base url is different than `https://westus.api.cognitive.microsoft.com`

### Changes made

#### **luisSdk.test.js** 
- Added `it` test method inside LuisClient suite.
- Some minor refactor changes for better legibility.
- Require `http-status-codes`.

### Testing

![image](https://user-images.githubusercontent.com/38112957/63802612-5f1a3900-c8e9-11e9-94ee-d104ef6fa29a.png)

