### PR TITLE
fix: [#4007] Bot framework V4. Unable to use ⭐ emoji in suggested actions

### DIFF
--- a/libraries/botbuilder-dialogs/src/choices/findValues.ts
+++ b/libraries/botbuilder-dialogs/src/choices/findValues.ts
@@ -98,6 +98,27 @@ export function findValues(
         return -1;
     }
 
+    function findExactMatch(utterance: string, values: SortedValue[]) {
+        return values
+            .filter((entry) => entry.value.toLowerCase() === utterance.toLowerCase())
+            .map((entry) => ({
+                text: utterance,
+                start: 0,
+                end: utterance.length - 1,
+                typeName: 'value',
+                resolution: {
+                    value: entry.value,
+                    index: entry.index,
+                    score: 1,
+                },
+            }));
+    }
+
+    const exactMatch = findExactMatch(utterance, values);
+    if (exactMatch?.length) {
+        return exactMatch;
+    }
+
     function matchValue(
         index: number,
         value: string,

--- a/libraries/botbuilder-dialogs/src/choices/findValues.ts
+++ b/libraries/botbuilder-dialogs/src/choices/findValues.ts
@@ -98,25 +98,26 @@ export function findValues(
         return -1;
     }
 
-    function findExactMatch(utterance: string, values: SortedValue[]) {
-        return values
-            .filter((entry) => entry.value.toLowerCase() === utterance.toLowerCase())
-            .map((entry) => ({
-                text: utterance,
-                start: 0,
-                end: utterance.length - 1,
-                typeName: 'value',
-                resolution: {
-                    value: entry.value,
-                    index: entry.index,
-                    score: 1,
-                },
-            }));
+    function findExactMatch(utterance: string, values: SortedValue[]): ModelResult<FoundValue> {
+        const entry = values.find(({ value }) => value.toLowerCase() === utterance.toLowerCase());
+        if (!entry) {
+            return null;
+        }
+        return {
+            text: utterance,
+            start: 0,
+            end: utterance.length - 1,
+            typeName: 'value',
+            resolution: {
+                value: entry.value,
+                index: entry.index,
+                score: 1,
+            },
+        };
     }
-
     const exactMatch = findExactMatch(utterance, values);
-    if (exactMatch?.length) {
-        return exactMatch;
+    if (exactMatch) {
+        return [exactMatch];
     }
 
     function matchValue(

--- a/libraries/botbuilder-dialogs/tests/choices_recognizers.test.js
+++ b/libraries/botbuilder-dialogs/tests/choices_recognizers.test.js
@@ -53,6 +53,12 @@ const similarValues = [
     { value: 'option C', index: 2 },
 ];
 
+const valuesWithSpecialCharacters = [
+    { value: 'A < B', index: 0 },
+    { value: 'A >= B', index: 1 },
+    { value: 'A ??? B', index: 2 },
+];
+
 describe('findValues()', function () {
     this.timeout(5000);
 
@@ -90,6 +96,14 @@ describe('findValues()', function () {
         const found = findValues(`option B`, similarValues, { allowPartialMatches: true });
         assert(found.length === 1, `Invalid token count of '${found.length}' returned.`);
         assertValue(found[0], 'option B', 1, 1.0);
+    });
+
+    it('should prefer exact match.', function () {
+        const index = 1;
+        const utterance = valuesWithSpecialCharacters[index].value;
+        const found = findValues(utterance, valuesWithSpecialCharacters);
+        assert(found.length === 1, `Invalid token count of '${found.length}' returned.`);
+        assertValue(found[0], utterance, index, 1);
     });
 });
 


### PR DESCRIPTION
Fixes # 4007

## Description
This PR ports the changes in [dotnet PR#4671](https://github.com/microsoft/botbuilder-dotnet/pull/4671) to add the _findExactMatch_ function in `botbuilder-dialogs/choices` to check for exact matches and bypass the tokenizer logic if an exact match is found.

## Specific Changes
- Updated `findValues` class to check for exact matches and bypass the rest of its logic if an exact match is found.
- Added a test to account for situations where multiple choices have the same word characters but different non-word characters.

## Testing
These images show the star choice being ignored, and after the fix, being properly recognized.
![image](https://user-images.githubusercontent.com/44245136/146563035-8df9c045-3e7f-4395-a327-c043522190cb.png)
